### PR TITLE
Initial Code Review

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "extends": "google",
+  "rules": {
+    "max-nested-callbacks": 0,
+    "valid-jsdoc": [2, {
+      "requireParamDescription": false,
+      "requireReturnDescription": false,
+      "prefer": {
+        "return": "returns"
+      }
+    }],
+    "no-warning-comments": 0
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/node_modules/

--- a/demo/another-index.html
+++ b/demo/another-index.html
@@ -1,0 +1,10 @@
+<html manifest="another-manifest.appcache">
+  <head>
+    <title>Possibly Cached</title>
+    <link rel="stylesheet" href="common.css">
+  </head>
+  <body>
+    <p>I might be served from the cache.</p>
+    <script src="../build/register-service-worker.js" data-service-worker="service-worker.js"></script>
+  </body>
+</html>

--- a/demo/another-manifest.appcache
+++ b/demo/another-manifest.appcache
@@ -3,6 +3,7 @@ CACHE MANIFEST
 
 CACHE:
 common.css
+../build/register-service-worker.js
 
 NETWORK:
 no-cache/

--- a/demo/another-manifest.appcache
+++ b/demo/another-manifest.appcache
@@ -1,0 +1,11 @@
+CACHE MANIFEST
+# v1
+
+CACHE:
+common.css
+
+NETWORK:
+no-cache/
+
+FALLBACK:
+can-fallback.html fallback.html

--- a/demo/can-fallback.html
+++ b/demo/can-fallback.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Can Fallback</title>
+    <link rel="stylesheet" href="common.css">
+  </head>
+  <body>
+    <p>I'm only displayed when the network is available.</p>
+  </body>
+</html>

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Fallback</title>
+    <link rel="stylesheet" href="common.css">
+  </head>
+  <body>
+    <p>I'm the fallback.</p>
+  </body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,10 @@
+<html manifest="manifest.appcache">
+  <head>
+    <title>Possibly Cached</title>
+    <link rel="stylesheet" href="common.css">
+  </head>
+  <body>
+    <p>I might be served from the cache.</p>
+    <script src="../build/register-service-worker.js" data-service-worker="service-worker.js"></script>
+  </body>
+</html>

--- a/demo/manifest.appcache
+++ b/demo/manifest.appcache
@@ -1,0 +1,12 @@
+CACHE MANIFEST
+# v1
+
+CACHE:
+common.css
+../build/register-service-worker.js
+
+NETWORK:
+*
+
+FALLBACK:
+can-fallback.html fallback.html

--- a/demo/no-cache/index.html
+++ b/demo/no-cache/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Never Cached</title>
+    <link rel="stylesheet" href="../common.css">
+  </head>
+  <body>
+    <p>I'm never served from the cache!</p>
+  </body>
+</html>

--- a/demo/service-worker.js
+++ b/demo/service-worker.js
@@ -1,0 +1,5 @@
+importScripts('../build/legacy-appcache-behavior-import.js');
+
+self.addEventListener('fetch', event => {
+  event.respondWith(legacyAppCacheBehavior(event));
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const gulp = require('gulp');
+
+const SRC_DIR = 'src';
+const BUILD_DIR = 'build';
+
+gulp.task('clean', () => {
+  const del = require('del');
+
+  return del(BUILD_DIR);
+});
+
+gulp.task('lint', () => {
+  const eslint = require('gulp-eslint');
+
+  return gulp.src(`${SRC_DIR}/**/*.js`)
+    .pipe(eslint())
+    .pipe(eslint.format())
+    .pipe(eslint.failOnError());
+});
+
+gulp.task('build', () => {
+  const browserify = require('browserify');
+  const buffer = require('vinyl-buffer');
+  const source = require('vinyl-source-stream');
+
+  [
+    'register-service-worker.js',
+    'legacy-appcache-behavior-import.js'
+  ].forEach(file => {
+    const bundler = browserify(`${SRC_DIR}/${file}`);
+
+    bundler.bundle()
+      .on('error', error => {
+        console.error(error);
+        bundler.emit('end');
+      })
+      .pipe(source(file))
+      .pipe(buffer())
+      .pipe(gulp.dest(BUILD_DIR));
+  });
+});
+
+gulp.task('default', callback => {
+  const sequence = require('run-sequence');
+
+  sequence('lint', 'clean', 'build', callback);
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "blueimp-md5": "^2.3.0",
     "browserify": "^13.0.0",
     "del": "^2.2.0",
     "eslint-config-google": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "appcache-to-service-worker",
+  "version": "1.0.0",
+  "description": "A service worker that mimics the behavior defined in a page's App Cache manifest.",
+  "keywords": [
+    "appcache",
+    "service worker",
+    "sw",
+    "offline",
+    "manifest"
+  ],
+  "author": {
+    "name": "Jeff Posnick",
+    "email": "jeffy@google.com",
+    "url": "https://jeffy.info"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "browserify": "^13.0.0",
+    "del": "^2.2.0",
+    "eslint-config-google": "^0.4.0",
+    "gulp": "^3.9.1",
+    "gulp-eslint": "^2.0.0",
+    "idb": "^1.1.0",
+    "parse-appcache-manifest": "^0.2.0",
+    "run-sequence": "^1.1.5",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
+  },
+  "engines": {
+    "node": ">=5.0.0"
+  }
+}

--- a/src/legacy-appcache-behavior-import.js
+++ b/src/legacy-appcache-behavior-import.js
@@ -5,7 +5,7 @@
   // Code in the ServiceWorkerGlobalScope can safely assume that a greater
   // set of ES2015 features are available, without having to transpile.
   
-  const log = console.debug;
+  const log = console.debug.bind(console);
 
   const constants = require('./lib/constants.js');
   let _db = null;
@@ -151,7 +151,6 @@
   function appCacheBehaviorForEvent(event) {
     const requestUrl = event.request.url;
     log('Starting appCacheBehaviorForUrl for', requestUrl);
-    log('X-Use-Fetch is', event.request.headers.get('X-Use-Fetch'));
 
     // If this is a request that, as per the AppCache spec, should be handled
     // via a direct fetch(), then do that and bail early.
@@ -160,6 +159,8 @@
       return fetch(event.request);
     }
 
+    // TODO: Use the client id mappings when possible.
+    // Refactor this code.
     return getDbInstance().then(db => {
       return getClientUrlForEvent(event).then(clientUrl => {
         log('clientUrl is', clientUrl);

--- a/src/legacy-appcache-behavior-import.js
+++ b/src/legacy-appcache-behavior-import.js
@@ -92,11 +92,10 @@
     const requestUrl = event.request.url;
     console.debug('Starting appCacheBehaviorForUrl for', requestUrl);
 
-    // If this is a request stemming from the CACHE or FALLBACK section of an
-    // AppCache manifest, used to initially populate the caches, then always
-    // use fetch().
-    if (event.request.headers.get('X-Use-Network') === 'true') {
-      console.debug('Using fetch() because X-Use-Network: true');
+    // If this is a request that, as per the AppCache spec, should be handled
+    // via a direct fetch(), then do that and bail early.
+    if (event.request.headers.get('X-Use-Fetch') === 'true') {
+      console.debug('Using fetch() because X-Use-Fetch: true');
       return fetch(event.request);
     }
 
@@ -110,16 +109,6 @@
             constants.OBJECT_STORES.PATH_TO_MANIFEST);
           return store.get(clientUrl).then(manifestUrl => {
             console.debug('manifestUrl is', manifestUrl);
-            // If this is a request for the AppCache manifest, that's simple.
-            if (manifestUrl === event.request.url) {
-              console.debug('manifestUrl matches; using fetch(event.request)');
-              // fetch() might get a copy from the browser cache. While this
-              // matches AppCache behavior, one of the enhancements
-              // in this library would be to get a fresh copy from the network
-              // iff the cached copy is more than 24 hours old.
-              // TODO: Implement that conditional cache busting.
-              return fetch(event.request);
-            }
 
             // Now, the complicated bit. First, see if we have a manifest
             // associated with the client. I.e., is manifestUrl defined?

--- a/src/legacy-appcache-behavior-import.js
+++ b/src/legacy-appcache-behavior-import.js
@@ -1,0 +1,244 @@
+/* eslint-env worker, serviceworker */
+
+(function(global) {
+  'use strict';
+  // Code in the ServiceWorkerGlobalScope can safely assume that a greater
+  // set of ES2015 features are available, without having to transpile.
+
+  const constants = require('./lib/constants.js');
+  let _db = null;
+
+  /**
+   * Gets an open instance of DB, a Promise-based wrapper on top of IndexedDB.
+   * If there's already a previously opened instance, it returns that.
+   *
+   * @returns {Promise.<DB>} The open DB instance
+   */
+  function getDbInstance() {
+    if (_db) {
+      return Promise.resolve(_db);
+    }
+
+    const idb = require('idb');
+    // The object stores will have been created by the web page prior to
+    // service worker registration.
+    return idb.open(constants.DB_NAME, constants.DB_VERSION).then(db => {
+      _db = db;
+      return _db;
+    });
+  }
+
+  /**
+   * Determines what the most likely URL is associated with the client page from
+   * which the event's request originates. This is used to determine which
+   * AppCache manifest's rules should be applied.
+   *
+   * @param {FetchEvent} event
+   * @returns {String} The client URL
+   */
+  function getClientUrlForEvent(event) {
+    // If our service worker implementation supports client identifiers, try
+    // to get the client URL using that.
+    if (global.clients && global.clients.get && event.clientId) {
+      return global.clients.get(event.clientId).then(client => client.url);
+    }
+
+    // Otherwise, try to get the client URL using the Referer header.
+    // And if that's not set, assume that it's a navigation request and the
+    // effective client URL should be the request URL.
+    // TODO: Is that a reasonable assumption?
+    return Promise.resolve(event.request.referrer || event.request.url);
+  }
+
+  /**
+   * Finds the longest matching prefix, given an array of possible matches.
+   *
+   * @param {Array.<String>} urlPrefixes
+   * @param {String} fullUrl
+   * @returns {String} The longest matching prefix, or '' if none match
+   */
+  function longestMatchingPrefix(urlPrefixes, fullUrl) {
+    return urlPrefixes
+      .filter(urlPrefix => fullUrl.startsWith(urlPrefix))
+      .reduce((longestSoFar, current) => {
+        return longestSoFar.length >= current.length ? longestSoFar : current;
+      }, '');
+  }
+
+  /**
+   * Performs a fetch(), using a cached response as a fallback if that fails.
+   *
+   * @param {Request} request
+   * @param {String} fallbackUrl
+   * @returns {Promise.<Response>}
+   */
+  function fetchWithFallback(request, fallbackUrl) {
+    console.debug('Trying fetch for', request.url);
+    return fetch(request).catch(() => {
+      console.debug('fetch() failed. Falling back to cache of', fallbackUrl);
+      return caches.open(constants.CACHE_NAME).then(
+        cache => cache.match(fallbackUrl));
+    });
+  }
+
+  /**
+   * An attempt to mimic AppCache behavior, using the primitives available to
+   * a service worker.
+   *
+   * @param {FetchEvent} event
+   * @returns {Promise.<Response>}
+   */
+  function appCacheBehaviorForEvent(event) {
+    const requestUrl = event.request.url;
+    console.debug('Starting appCacheBehaviorForUrl for', requestUrl);
+
+    // If this is a request stemming from the CACHE or FALLBACK section of an
+    // AppCache manifest, used to initially populate the caches, then always
+    // use fetch().
+    if (event.request.headers.get('X-Use-Network') === 'true') {
+      console.debug('Using fetch() because X-Use-Network: true');
+      return fetch(event.request);
+    }
+
+    return getDbInstance().then(db => {
+      return getClientUrlForEvent(event).then(clientUrl => {
+        console.debug('clientUrl is', clientUrl);
+        if (clientUrl) {
+          const tx = db.transaction(
+            constants.OBJECT_STORES.PATH_TO_MANIFEST);
+          const store = tx.objectStore(
+            constants.OBJECT_STORES.PATH_TO_MANIFEST);
+          return store.get(clientUrl).then(manifestUrl => {
+            console.debug('manifestUrl is', manifestUrl);
+            // If this is a request for the AppCache manifest, that's simple.
+            if (manifestUrl === event.request.url) {
+              console.debug('manifestUrl matches; using fetch(event.request)');
+              // fetch() might get a copy from the browser cache. While this
+              // matches AppCache behavior, one of the enhancements
+              // in this library would be to get a fresh copy from the network
+              // iff the cached copy is more than 24 hours old.
+              // TODO: Implement that conditional cache busting.
+              return fetch(event.request);
+            }
+
+            // Now, the complicated bit. First, see if we have a manifest
+            // associated with the client. I.e., is manifestUrl defined?
+            if (manifestUrl) {
+              // If we know which manifest applies, let's put it to use.
+              const manifestTx = db.transaction(
+                constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+              const manifestStore = manifestTx.objectStore(
+                constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+
+              return manifestStore.get(manifestUrl).then(manifest => {
+                console.debug('manifest is', manifest);
+                // Is our request URL listed in the CACHES section?
+                // Or is our request URL the client URL, since any page that
+                // registers a manifest is treated as if it were in the CACHE?
+                if (manifest.parsed.cache.includes(requestUrl) ||
+                    requestUrl === clientUrl) {
+                  console.debug('CACHE includes URL; using cache.match()');
+                  // If so, return the cached response.
+                  return caches.open(constants.CACHE_NAME).then(
+                    cache => cache.match(requestUrl));
+                }
+
+                // Otherwise, check the FALLBACK section next.
+                // FALLBACK keys are URL prefixes, and if more than one prefix
+                // matches our request URL, the longest prefix "wins".
+                // (Of course, it might be that none of the prefixes match.)
+                const fallbackKey = longestMatchingPrefix(
+                  Object.keys(manifest.parsed.fallback), requestUrl);
+                if (fallbackKey) {
+                  console.debug('fallbackKey in manifest matches', fallbackKey);
+                  return fetchWithFallback(event.request,
+                    manifest.parsed.fallback[fallbackKey]);
+                }
+
+                // If CACHE and FALLBACK don't apply, try NETWORK.
+                if (manifest.parsed.network.includes(requestUrl) ||
+                  manifest.parsed.network.includes('*')) {
+                  console.debug('Match or * in NETWORK; using fetch()');
+                  return fetch(event.request);
+                }
+
+                // If nothing matches, then return an error response.
+                // TODO: Is returning Response.error() the best approach?
+                console.debug('Nothing matches; using Response.error()');
+                return Response.error();
+              });
+            }
+
+            console.debug('No matching manifest for client found.');
+            // If we fall through to this point, then we don't have a known
+            // manifest associated with the client making the request.
+            // We now need to check to see if our request URL matches a prefix
+            // from the FALLBACK section of *any* manifest in our origin. If
+            // there are multiple matches, the longest prefix wins. If there are
+            // multiple prefixes of the same length in different manifest, then
+            // the one returned last from IDB wins. (This might not match
+            // browser behavior.)
+            // See https://www.w3.org/TR/2011/WD-html5-20110525/offline.html#concept-appcache-matches-fallback
+            const tx = db.transaction(
+              constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+            const store = tx.objectStore(
+              constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+            return store.getAll().then(manifests => {
+              console.debug('All manifests:', manifests);
+              // Use .map() to create an array of the longest matching prefix
+              // for each manifest. If no prefixes match for a given manifest,
+              // the value will be ''.
+              const longestForEach = manifests.map(manifest => {
+                return longestMatchingPrefix(
+                  Object.keys(manifest.parsed.fallback), requestUrl);
+              });
+              console.debug('longestForEach:', longestForEach);
+
+              // Next, find which of the longest matching prefixes from each
+              // manifest is the longest overall. Return both the index of the
+              // manifest in which that match appears and the prefix itself.
+              const longest = longestForEach.reduce((soFar, current, i) => {
+                if (current.length >= soFar.prefix.length) {
+                  return {prefix: current, index: i};
+                }
+
+                return soFar;
+              }, {prefix: '', index: 0});
+              console.debug('longest:', longest);
+
+              // Now that we know the longest overall prefix, we'll use that
+              // to lookup the fallback URL value in the winning manifest.
+              const fallbackKey = longest.prefix;
+              console.debug('fallbackKey:', fallbackKey);
+              if (fallbackKey) {
+                const winningManifest = manifests[longest.index];
+                console.debug('winningManifest:', winningManifest);
+                return fetchWithFallback(event.request,
+                  winningManifest.parsed.fallback[fallbackKey]);
+              }
+
+              // If nothing matches, then just fetch().
+              console.debug('Nothing at all matches. Using fetch()');
+              return fetch(event.request);
+            });
+          });
+        }
+      });
+    });
+  }
+
+  /**
+   * A wrapper on top of appCacheBehaviorForEvent() that handles rejections with
+   * a default of fetch().
+   *
+   * @param {FetchEvent} event
+   * @returns {Promise.<Response>}
+   */
+  global.legacyAppCacheBehavior = event => {
+    return appCacheBehaviorForEvent(event).catch(error => {
+      console.warn(`No AppCache behavior for ${event.request.url}:`, error);
+      // TODO: Is it sensible to use fetch() here as a fallback?
+      return fetch(event.request);
+    });
+  };
+})(self);

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,8 +1,8 @@
 module.exports = {
-  CACHE_NAME: 'appcache-manifest-entries',
   DB_NAME: 'appcache-to-service-worker',
   DB_VERSION: 1,
   OBJECT_STORES: {
+    CLIENT_ID_TO_HASH: 'client-to-hash',
     MANIFEST_URL_TO_CONTENTS: 'manifest-url-to-contents',
     PATH_TO_MANIFEST: 'path-to-manifest'
   }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,7 +1,7 @@
 module.exports = {
   DB_NAME: 'appcache-to-service-worker',
   DB_VERSION: 1,
-  OBJECT_STORES: {
+  STORES: {
     CLIENT_ID_TO_HASH: 'client-to-hash',
     MANIFEST_URL_TO_CONTENTS: 'manifest-url-to-contents',
     PATH_TO_MANIFEST: 'path-to-manifest'

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,0 +1,9 @@
+module.exports = {
+  CACHE_NAME: 'appcache-manifest-entries',
+  DB_NAME: 'appcache-to-service-worker',
+  DB_VERSION: 1,
+  OBJECT_STORES: {
+    MANIFEST_URL_TO_CONTENTS: 'manifest-url-to-contents',
+    PATH_TO_MANIFEST: 'path-to-manifest'
+  }
+};

--- a/src/lib/idb-helpers.js
+++ b/src/lib/idb-helpers.js
@@ -1,0 +1,109 @@
+const constants = require('./constants.js');
+
+let _db = null;
+
+/**
+ * Gets an open instance of DB, a Promise-based wrapper on top of IndexedDB.
+ * If there's already a previously opened instance, it returns that.
+ *
+ * @returns {Promise.<DB>} The open DB instance
+ */
+function getDbInstance() {
+  if (_db) {
+    return Promise.resolve(_db);
+  }
+
+  const idb = require('idb');
+  // The object stores will have been created by the web page prior to
+  // service worker registration.
+  return idb.open(constants.DB_NAME, constants.DB_VERSION).then(db => {
+    _db = db;
+    return _db;
+  });
+}
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies saving the key/value
+ * pair to the object store.
+ * Returns a Promise that fulfills when the transaction completes.
+ *
+ * @param {String} storeName
+ * @param {String} key
+ * @param {Object} value
+ * @returns {Promise.<T>}
+ */
+module.exports.put = (storeName, key, value) => {
+  return getDbInstance().then(db => {
+    const tx = db.transaction(storeName, 'readwrite');
+    const objectStore = tx.objectStore(storeName);
+    objectStore.put(value, key);
+    return tx.complete;
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies deleting an entry
+ * from the object store.
+ * Returns a Promise that fulfills when the transaction completes.
+ *
+ * @param {String} storeName
+ * @param {String} key
+ * @returns {Promise.<T>}
+ */
+module.exports.delete = (storeName, key) => {
+  return getDbInstance().then(db => {
+    const tx = db.transaction(storeName, 'readwrite');
+    const objectStore = tx.objectStore(storeName);
+    objectStore.delete(key);
+    return tx.complete;
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies getting a key's value
+ * from the object store.
+ * Returns a promise that fulfills with the value.
+ *
+ * @param {String} storeName
+ * @param {String} key
+ * @returns {Promise.<Object>}
+ */
+module.exports.get = (storeName, key) => {
+  return getDbInstance().then(db => {
+    const tx = db.transaction(storeName);
+    const objectStore = tx.objectStore(storeName);
+    return objectStore.get(key);
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies getting all the values
+ * in an object store.
+ * Returns a promise that fulfills with all the values.
+ *
+ * @param {String} storeName
+ * @returns {Promise.<Array.<Object>>}
+ */
+module.exports.getAll = storeName => {
+  return getDbInstance().then(db => {
+    const tx = db.transaction(storeName);
+    const objectStore = tx.objectStore(storeName);
+    return objectStore.getAll();
+  });
+};
+
+/**
+ * Wrapper on top of the idb wrapper, which simplifies getting all the keys
+ * in an object store.
+ * Returns a promise that fulfills with all the keys.
+ *
+ * @param {String} storeName
+ * @returns {Promise.<Array.<Object>>}
+ */
+module.exports.getAllKeys = storeName => {
+  return getDbInstance().then(db => {
+    const tx = db.transaction(storeName);
+    const objectStore = tx.objectStore(storeName);
+    return objectStore.getAllKeys();
+  });
+};

--- a/src/register-service-worker.js
+++ b/src/register-service-worker.js
@@ -1,162 +1,166 @@
 /* eslint-env browser */
 
-(function() {
-  var constants = require('./lib/constants.js');
+var constants = require('./lib/constants.js');
 
-  var swScript = document.currentScript.dataset.serviceWorker;
-  var manifestAttribute = document.documentElement.getAttribute('manifest');
+var swScript = document.currentScript.dataset.serviceWorker;
+var manifestAttribute = document.documentElement.getAttribute('manifest');
 
-  if (swScript && manifestAttribute && 'serviceWorker' in navigator) {
-    var manifestUrl = (new URL(manifestAttribute, location.href)).href;
+if (manifestAttribute && 'serviceWorker' in navigator) {
+  var manifestUrl = (new URL(manifestAttribute, location.href)).href;
 
-    var idb = require('idb');
+  var idb = require('idb');
 
-    idb.open(constants.DB_NAME, constants.DB_VERSION, function(upgradeDB) {
-      if (upgradeDB.oldVersion === 0) {
-        Object.keys(constants.OBJECT_STORES).forEach(function(objectStore) {
-          upgradeDB.createObjectStore(constants.OBJECT_STORES[objectStore]);
-        });
-      }
-    }).then(function(db) {
-      return Promise.all([
-        updateManifestAssociationForCurrentPage(db, manifestUrl),
-        handlePossibleManifestUpdate(db, manifestUrl)
-      ]);
-    }).then(function() {
+  idb.open(constants.DB_NAME, constants.DB_VERSION, function(upgradeDB) {
+    if (upgradeDB.oldVersion === 0) {
+      Object.keys(constants.OBJECT_STORES).forEach(function(objectStore) {
+        upgradeDB.createObjectStore(constants.OBJECT_STORES[objectStore]);
+      });
+    }
+  }).then(function(db) {
+    return Promise.all([
+      updateManifestAssociationForCurrentPage(db, manifestUrl),
+      handlePossibleManifestUpdate(db, manifestUrl)
+    ]);
+  }).then(function() {
+    if (swScript) {
       return navigator.serviceWorker.register(swScript);
-    });
-  }
+    }
+  });
+}
 
-  /**
-   * Caches the Responses for one or more URLs, using the Cache Storage API.
-   *
-   * @param {Array.<String>} urls
-   * @returns {Promise.<T>}
-   */
-  function addToCache(urls) {
-    return caches.open(constants.CACHE_NAME).then(function(cache) {
-      return cache.addAll(urls.map(function(url) {
-        // These caching requests need to always result in a fetch() even if
-        // there's a service worker that might otherwise treat them differently.
-        // Let's use this special request header to let the service worker know.
-        return new Request(url, {headers: {'X-Use-Network': true}});
-      }));
-    });
-  }
+/**
+ * Caches the Responses for one or more URLs, using the Cache Storage API.
+ *
+ * @param {Array.<String>} urls
+ * @returns {Promise.<T>}
+ */
+function addToCache(urls) {
+  return caches.open(constants.CACHE_NAME).then(function(cache) {
+    return cache.addAll(urls.map(function(url) {
+      // These caching requests need to always result in a fetch() even if
+      // there's a service worker that might otherwise treat them differently.
+      // Let's use this special request header to let the service worker know.
+      return new Request(url, {headers: {'X-Use-Network': true}});
+    }));
+  });
+}
 
-  /**
-   * Compares the copy of a manifest obtained from fetch() with the copy stored
-   * in IndexedDB. If they differ, it kicks off the manifest update process.
-   *
-   * @param {DB} db
-   * @param {String} manifestUrl
-   * @returns {Promise.<T>}
-   */
-  function handlePossibleManifestUpdate(db, manifestUrl) {
-    var tx = db.transaction(constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
-    var store = tx.objectStore(
-      constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+/**
+ * Compares the copy of a manifest obtained from fetch() with the copy stored
+ * in IndexedDB. If they differ, it kicks off the manifest update process.
+ *
+ * @param {DB} db
+ * @param {String} manifestUrl
+ * @returns {Promise.<T>}
+ */
+function handlePossibleManifestUpdate(db, manifestUrl) {
+  var tx = db.transaction(constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+  var store = tx.objectStore(
+    constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
 
-    return Promise.all([
-      fetch(manifestUrl).then(function(manifestResponse) {
-        return manifestResponse.text();
-      }),
-      store.get(manifestUrl).then(function(idbEntryForManifest) {
-        return idbEntryForManifest ? idbEntryForManifest.text : '';
-      })
-    ]).then(function(manifestTexts) {
-      // manifestTexts[0] is the text content from the fetch().
-      // manifestTexts[1] is the text content from IDB.
-      if (manifestTexts[0] !== manifestTexts[1]) {
-        return performManifestUpdate(db, manifestUrl, manifestTexts[0]);
-      }
-    });
-  }
+  return Promise.all([
+    fetch(manifestUrl).then(function(manifestResponse) {
+      return manifestResponse.text();
+    }),
+    store.get(manifestUrl).then(function(idbEntryForManifest) {
+      return idbEntryForManifest ? idbEntryForManifest.text : '';
+    })
+  ]).then(function(manifestTexts) {
+    // manifestTexts[0] is the text content from the fetch().
+    // manifestTexts[1] is the text content from IDB.
+    if (manifestTexts[0] !== manifestTexts[1]) {
+      return performManifestUpdate(db, manifestUrl, manifestTexts[0]);
+    }
+  });
+}
 
-  /**
-   * Parses the newest manifest text into the format described at
-   * https://www.npmjs.com/package/parse-appcache-manifest
-   * The parsed manifest is stored in IndexedDB.
-   * This also calls addToCache() to cache the relevant URLs from the manifest.
-   *
-   * @param {DB} db
-   * @param {String} manifestUrl
-   * @param {String} manifestText
-   * @returns {Promise.<T>}
-   */
-  function performManifestUpdate(db, manifestUrl, manifestText) {
-    var parseAppCacheManifest = require('parse-appcache-manifest');
-    var parsedManifest = makeManifestUrlsAbsolute(manifestUrl,
-      parseAppCacheManifest(manifestText));
+/**
+ * Parses the newest manifest text into the format described at
+ * https://www.npmjs.com/package/parse-appcache-manifest
+ * The parsed manifest is stored in IndexedDB.
+ * This also calls addToCache() to cache the relevant URLs from the manifest.
+ *
+ * @param {DB} db
+ * @param {String} manifestUrl
+ * @param {String} manifestText
+ * @returns {Promise.<T>}
+ */
+function performManifestUpdate(db, manifestUrl, manifestText) {
+  var parseAppCacheManifest = require('parse-appcache-manifest');
+  var parsedManifest = makeManifestUrlsAbsolute(manifestUrl,
+    parseAppCacheManifest(manifestText));
 
-    var tx = db.transaction(constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS,
-      'readwrite');
-    var store = tx.objectStore(
-      constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+  var tx = db.transaction(constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS,
+    'readwrite');
+  var store = tx.objectStore(
+    constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
 
-    var fallbackUrls = Object.keys(parsedManifest.fallback).map(function(key) {
-      return parsedManifest.fallback[key];
-    });
+  var fallbackUrls = Object.keys(parsedManifest.fallback).map(function(key) {
+    return parsedManifest.fallback[key];
+  });
 
-    return Promise.all([
-      store.put({
-        text: manifestText,
-        parsed: parsedManifest
-      }, manifestUrl),
-      addToCache(parsedManifest.cache.concat(fallbackUrls))
-    ]);
-  }
+  return Promise.all([
+    store.put({
+      text: manifestText,
+      parsed: parsedManifest
+    }, manifestUrl),
+    // Wait on tx.complete to ensure that the transaction succeeded.
+    tx.complete,
+    addToCache(parsedManifest.cache.concat(fallbackUrls))
+  ]);
+}
 
-  /**
-   * Updates IndexedDB to indicate that the current page's URL is associated
-   * with the AppCache manifest at manifestUrl.
-   * It also adds the current page to the cache, matching the implicit
-   * cache-as-you-go behavior you get with AppCache.
-   *
-   * @param {DB} db
-   * @param {String} manifestUrl
-   * @returns {Promise.<T>}
-   */
-  function updateManifestAssociationForCurrentPage(db, manifestUrl) {
-    var tx = db.transaction(constants.OBJECT_STORES.PATH_TO_MANIFEST,
-      'readwrite');
-    var store = tx.objectStore(constants.OBJECT_STORES.PATH_TO_MANIFEST);
+/**
+ * Updates IndexedDB to indicate that the current page's URL is associated
+ * with the AppCache manifest at manifestUrl.
+ * It also adds the current page to the cache, matching the implicit
+ * cache-as-you-go behavior you get with AppCache.
+ *
+ * @param {DB} db
+ * @param {String} manifestUrl
+ * @returns {Promise.<T>}
+ */
+function updateManifestAssociationForCurrentPage(db, manifestUrl) {
+  var tx = db.transaction(constants.OBJECT_STORES.PATH_TO_MANIFEST,
+    'readwrite');
+  var store = tx.objectStore(constants.OBJECT_STORES.PATH_TO_MANIFEST);
 
-    return Promise.all([
-      store.put(manifestUrl, location.href),
-      addToCache([location.href])
-    ]);
-  }
+  return Promise.all([
+    store.put(manifestUrl, location.href),
+    // Wait on tx.complete to ensure that the transaction succeeded.
+    tx.complete,
+    addToCache([location.href])
+  ]);
+}
 
-  /**
-   * Converts all the URLs in a given manifest's CACHE, NETWORK, and FALLBACK
-   * sections to be absolute URLs.
-   *
-   * @param {String} baseUrl
-   * @param {Object} originalManifest
-   * @returns {Object}
-   */
-  function makeManifestUrlsAbsolute(baseUrl, originalManifest) {
-    var manifest = {};
+/**
+ * Converts all the URLs in a given manifest's CACHE, NETWORK, and FALLBACK
+ * sections to be absolute URLs.
+ *
+ * @param {String} baseUrl
+ * @param {Object} originalManifest
+ * @returns {Object}
+ */
+function makeManifestUrlsAbsolute(baseUrl, originalManifest) {
+  var manifest = {};
 
-    manifest.cache = originalManifest.cache.map(function(relativeUrl) {
-      return (new URL(relativeUrl, baseUrl)).href;
-    });
+  manifest.cache = originalManifest.cache.map(function(relativeUrl) {
+    return (new URL(relativeUrl, baseUrl)).href;
+  });
 
-    manifest.network = originalManifest.network.map(function(relativeUrl) {
-      if (relativeUrl === '*') {
-        return relativeUrl;
-      }
+  manifest.network = originalManifest.network.map(function(relativeUrl) {
+    if (relativeUrl === '*') {
+      return relativeUrl;
+    }
 
-      return (new URL(relativeUrl, baseUrl)).href;
-    });
+    return (new URL(relativeUrl, baseUrl)).href;
+  });
 
-    manifest.fallback = {};
-    Object.keys(originalManifest.fallback).forEach(function(key) {
-      manifest.fallback[(new URL(key, baseUrl)).href] =
-        (new URL(originalManifest.fallback[key], baseUrl)).href;
-    });
+  manifest.fallback = {};
+  Object.keys(originalManifest.fallback).forEach(function(key) {
+    manifest.fallback[(new URL(key, baseUrl)).href] =
+      (new URL(originalManifest.fallback[key], baseUrl)).href;
+  });
 
-    return manifest;
-  }
-})();
+  return manifest;
+}

--- a/src/register-service-worker.js
+++ b/src/register-service-worker.js
@@ -1,0 +1,162 @@
+/* eslint-env browser */
+
+(function() {
+  var constants = require('./lib/constants.js');
+
+  var swScript = document.currentScript.dataset.serviceWorker;
+  var manifestAttribute = document.documentElement.getAttribute('manifest');
+
+  if (swScript && manifestAttribute && 'serviceWorker' in navigator) {
+    var manifestUrl = (new URL(manifestAttribute, location.href)).href;
+
+    var idb = require('idb');
+
+    idb.open(constants.DB_NAME, constants.DB_VERSION, function(upgradeDB) {
+      if (upgradeDB.oldVersion === 0) {
+        Object.keys(constants.OBJECT_STORES).forEach(function(objectStore) {
+          upgradeDB.createObjectStore(constants.OBJECT_STORES[objectStore]);
+        });
+      }
+    }).then(function(db) {
+      return Promise.all([
+        updateManifestAssociationForCurrentPage(db, manifestUrl),
+        handlePossibleManifestUpdate(db, manifestUrl)
+      ]);
+    }).then(function() {
+      return navigator.serviceWorker.register(swScript);
+    });
+  }
+
+  /**
+   * Caches the Responses for one or more URLs, using the Cache Storage API.
+   *
+   * @param {Array.<String>} urls
+   * @returns {Promise.<T>}
+   */
+  function addToCache(urls) {
+    return caches.open(constants.CACHE_NAME).then(function(cache) {
+      return cache.addAll(urls.map(function(url) {
+        // These caching requests need to always result in a fetch() even if
+        // there's a service worker that might otherwise treat them differently.
+        // Let's use this special request header to let the service worker know.
+        return new Request(url, {headers: {'X-Use-Network': true}});
+      }));
+    });
+  }
+
+  /**
+   * Compares the copy of a manifest obtained from fetch() with the copy stored
+   * in IndexedDB. If they differ, it kicks off the manifest update process.
+   *
+   * @param {DB} db
+   * @param {String} manifestUrl
+   * @returns {Promise.<T>}
+   */
+  function handlePossibleManifestUpdate(db, manifestUrl) {
+    var tx = db.transaction(constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+    var store = tx.objectStore(
+      constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+
+    return Promise.all([
+      fetch(manifestUrl).then(function(manifestResponse) {
+        return manifestResponse.text();
+      }),
+      store.get(manifestUrl).then(function(idbEntryForManifest) {
+        return idbEntryForManifest ? idbEntryForManifest.text : '';
+      })
+    ]).then(function(manifestTexts) {
+      // manifestTexts[0] is the text content from the fetch().
+      // manifestTexts[1] is the text content from IDB.
+      if (manifestTexts[0] !== manifestTexts[1]) {
+        return performManifestUpdate(db, manifestUrl, manifestTexts[0]);
+      }
+    });
+  }
+
+  /**
+   * Parses the newest manifest text into the format described at
+   * https://www.npmjs.com/package/parse-appcache-manifest
+   * The parsed manifest is stored in IndexedDB.
+   * This also calls addToCache() to cache the relevant URLs from the manifest.
+   *
+   * @param {DB} db
+   * @param {String} manifestUrl
+   * @param {String} manifestText
+   * @returns {Promise.<T>}
+   */
+  function performManifestUpdate(db, manifestUrl, manifestText) {
+    var parseAppCacheManifest = require('parse-appcache-manifest');
+    var parsedManifest = makeManifestUrlsAbsolute(manifestUrl,
+      parseAppCacheManifest(manifestText));
+
+    var tx = db.transaction(constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS,
+      'readwrite');
+    var store = tx.objectStore(
+      constants.OBJECT_STORES.MANIFEST_URL_TO_CONTENTS);
+
+    var fallbackUrls = Object.keys(parsedManifest.fallback).map(function(key) {
+      return parsedManifest.fallback[key];
+    });
+
+    return Promise.all([
+      store.put({
+        text: manifestText,
+        parsed: parsedManifest
+      }, manifestUrl),
+      addToCache(parsedManifest.cache.concat(fallbackUrls))
+    ]);
+  }
+
+  /**
+   * Updates IndexedDB to indicate that the current page's URL is associated
+   * with the AppCache manifest at manifestUrl.
+   * It also adds the current page to the cache, matching the implicit
+   * cache-as-you-go behavior you get with AppCache.
+   *
+   * @param {DB} db
+   * @param {String} manifestUrl
+   * @returns {Promise.<T>}
+   */
+  function updateManifestAssociationForCurrentPage(db, manifestUrl) {
+    var tx = db.transaction(constants.OBJECT_STORES.PATH_TO_MANIFEST,
+      'readwrite');
+    var store = tx.objectStore(constants.OBJECT_STORES.PATH_TO_MANIFEST);
+
+    return Promise.all([
+      store.put(manifestUrl, location.href),
+      addToCache([location.href])
+    ]);
+  }
+
+  /**
+   * Converts all the URLs in a given manifest's CACHE, NETWORK, and FALLBACK
+   * sections to be absolute URLs.
+   *
+   * @param {String} baseUrl
+   * @param {Object} originalManifest
+   * @returns {Object}
+   */
+  function makeManifestUrlsAbsolute(baseUrl, originalManifest) {
+    var manifest = {};
+
+    manifest.cache = originalManifest.cache.map(function(relativeUrl) {
+      return (new URL(relativeUrl, baseUrl)).href;
+    });
+
+    manifest.network = originalManifest.network.map(function(relativeUrl) {
+      if (relativeUrl === '*') {
+        return relativeUrl;
+      }
+
+      return (new URL(relativeUrl, baseUrl)).href;
+    });
+
+    manifest.fallback = {};
+    Object.keys(originalManifest.fallback).forEach(function(key) {
+      manifest.fallback[(new URL(key, baseUrl)).href] =
+        (new URL(originalManifest.fallback[key], baseUrl)).href;
+    });
+
+    return manifest;
+  }
+})();


### PR DESCRIPTION
R: @jakearchibald @slightlyoff

Here's a reworked attempt at a runtime implementation of mimicking AppCache behavior with a service worker.

Unlike the initial attempt, this doesn't use `sw-toolbox`, since `sw-toolbox` has a global set of routes that doesn't map well to the multiple-manifests-in-the-same-origin scenario.

It now uses `IndexedDB` to store manifest contents and URL-to-manifest associations, and should properly handle manifest upgrades, multiple manifests in the same origin, and the implicit caching of pages that use a manifest.

Developers can opt-in to using the AppCache behavior in their main `fetch` event handler based on whatever criteria they'd like to apply, which is something that Jake suggested. If they're rather use a different behavior for a subset of URLs, they just don't call `legacyAppCacheBehavior(event)`.

In terms of review, while I'd obviously appreciate you looking at the code, it would also be really helpful if you could read through the comments (especially the `TODO` ones) and confirm the assumptions that I'm making. I've tried to follow [Jake's diagram](https://www.flickr.com/photos/jaffathecake/8015087167) as best as I could, explaining my logic each step of the way, but it's entirely possible that I've misinterpretted something subtle.

The easiest way to test out the code would be to clone this branch, run `npm install; gulp`, then start up a local web server and visit the `/demo/` directory. There are copious `console.debug()` statements in the current code that will give you a noisy view as to what's going on.

Once I get through this initial code review with you both, I'd like to move the code out of this repo and into somewhere under `GoogleChrome`, and then try to solicit some third-party feedback on a `0.0.1` release.
